### PR TITLE
Fix typo in method signature

### DIFF
--- a/src/main/java/com/apple/eawt/SystemSleepListener.java
+++ b/src/main/java/com/apple/eawt/SystemSleepListener.java
@@ -3,5 +3,5 @@ package com.apple.eawt;
 /** @since 10.6 Update 3 and 10.5 Update 8 */
 public interface SystemSleepListener extends AppEventListener {
     public void systemAboutToSleep(AppEvent.SystemSleepEvent e);
-    public void systemAweoke(AppEvent.SystemSleepEvent e);
+    public void systemAwoke(AppEvent.SystemSleepEvent e);
 }


### PR DESCRIPTION
The `SystemSleepListener` interface has a method:

``` java
void systemAwoke(AppEvent.SystemSleepEvent e);
```

But it was stubbed here as:

``` java
void systemAweoke(AppEvent.SystemSleepEvent e);
```

Which caused classes implementing `SystemSleepListener` to fail compilation on non-OS-X platforms.
